### PR TITLE
Allow users with no friends to log in successfully

### DIFF
--- a/Thirty/Thirty/AppDelegate.swift
+++ b/Thirty/Thirty/AppDelegate.swift
@@ -17,7 +17,7 @@ import Intents
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, PKPushRegistryDelegate {
 
     var window: UIWindow?
-    private var loggedIn: Bool { return FirebaseManager.shared.currentUserIsSignedIn }
+    private var loggedIn: Bool { return FirebaseManager.shared.currentUserIsLoggedIn }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         CallManager.shared.configure()
@@ -54,7 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             let tokenData = pushCredentials.token
             let voipPushToken = tokenData.map { String(format: "%02.2hhx", $0) }.joined()
             TokenUtils.deviceToken = voipPushToken
-            if FirebaseManager.shared.currentUserIsSignedIn {
+            if FirebaseManager.shared.currentUserIsLoggedIn {
                 FirebaseManager.shared.updateDeviceToken()
             }
         }


### PR DESCRIPTION
**NOTE**: Branched off of work done in #8, so review/merge that first so that only relevant changes are seen here. This was done in an attempt to avoid doing double the work when rebasing/merging this later. 

In `FirebaseManager.swift`:
- Primary work was done in `FirebaseManager.getContacts(:)`, that was where the bug was.
- Also ended up refactoring the class a bit— I didn't touch the insides of any methods, but mostly just rearranged the properties, and organized the methods by grouping relevant ones together with pragma marks. 

Moving forward, I think we should touch this class as little as possible- there's a lot that could go wrong with Firebase, (primarily the lack of callback when it cant connect, leaving the method hanging _forever_), so I really think the first priority post-deadline is to figure out a different solution for storing user data. What's nice is that we can store the data basically the same way, but get a bunch of conveniences for how we get it by using a server. (eg - dont have to fetch each username then user, we can just ask the server for all of this user's friends. one callback, _thats it_ ).

